### PR TITLE
URLを地域Ruby会議のドメインに変更

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: 川崎Ruby会議01
 description: kawasaki.rb主催の地域Ruby会議「川崎Ruby会議01」の情報を掲載しています
 baseurl: "/kwsk01"
-url: "http://kawasakirb.github.io"
+url: "http://regional.rubykaigi.org"
 twitter_username: kawasakirb
 github_username:  kawasakirb
 encoding: UTF-8


### PR DESCRIPTION
すいません変え忘れていました。
kawasakirb.github.ioがGoogleで見え続けるのもこのせい?
